### PR TITLE
Feature request: honeypot support

### DIFF
--- a/src/Akismet.php
+++ b/src/Akismet.php
@@ -96,7 +96,7 @@ class Akismet
             $this->setIsTest($attributes['is_test']);
         }
         if(isset($attributes['hidden_honeypot_field'])) {
-            $this->setHoneypotFieldName($attributes['hidden_honeypot_field']);
+            $this->setHiddenHoneypotField($attributes['hidden_honeypot_field']);
         }
         if(isset($attributes['honeypot_field_name'])) {
             $this->setHoneypotFieldName($attributes['honeypot_field_name']);
@@ -445,19 +445,19 @@ class Akismet
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getHiddenHoneypotField(): string
+    public function getHiddenHoneypotField(): ?string
     {
         return $this->hiddenHoneypotField;
     }
 
     /**
-     * @param string $hiddenHoneypotField
+     * @param string|null $hiddenHoneypotField
      * 
      * @return self
      */
-    public function setHiddenHoneypotField(string $hiddenHoneypotField): self
+    public function setHiddenHoneypotField(?string $hiddenHoneypotField): self
     {
         $this->hiddenHoneypotField = $hiddenHoneypotField;
 
@@ -465,19 +465,19 @@ class Akismet
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getHoneypotFieldName(): string
+    public function getHoneypotFieldName(): ?string
     {
         return $this->honeypotFieldName;
     }
 
     /**
-     * @param string $honeypotFieldName
+     * @param string|null $honeypotFieldName
      * 
      * @return self
      */
-    public function setHoneypotFieldName(string $honeypotFieldName): self
+    public function setHoneypotFieldName(?string $honeypotFieldName): self
     {
         $this->honeypotFieldName = $honeypotFieldName;
 

--- a/src/Akismet.php
+++ b/src/Akismet.php
@@ -34,6 +34,12 @@ class Akismet
     /** @var string */
     protected $commentType;
 
+    /** @var string */
+    protected $honeypotFieldName;
+
+    /** @var string */
+    protected $hiddenHoneypotField;
+
     /** @var bool */
     protected $isTest = false;
 
@@ -88,6 +94,12 @@ class Akismet
         }
         if (isset($attributes['is_test'])) {
             $this->setIsTest($attributes['is_test']);
+        }
+        if(isset($attributes['hidden_honeypot_field'])) {
+            $this->setHoneypotFieldName($attributes['hidden_honeypot_field']);
+        }
+        if(isset($attributes['honeypot_field_name'])) {
+            $this->setHoneypotFieldName($attributes['honeypot_field_name']);
         }
 
         return $this;
@@ -155,6 +167,8 @@ class Akismet
             'comment_content' => $this->getCommentContent(),
             'blog' => $this->getBlogUrl(),
             'is_test' => $this->getIsTest(),
+            'hidden_honeypot_field' => $this->getHiddenHoneypotField(),
+            'honeypot_field_name' => $this->getHoneypotFieldName()
         ];
     }
 
@@ -426,6 +440,46 @@ class Akismet
     public function setApiVersion($apiVersion)
     {
         $this->apiVersion = $apiVersion;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHiddenHoneypotField(): string
+    {
+        return $this->hiddenHoneypotField;
+    }
+
+    /**
+     * @param string $hiddenHoneypotField
+     * 
+     * @return self
+     */
+    public function setHiddenHoneypotField(string $hiddenHoneypotField): self
+    {
+        $this->hiddenHoneypotField = $hiddenHoneypotField;
+
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getHoneypotFieldName(): string
+    {
+        return $this->honeypotFieldName;
+    }
+
+    /**
+     * @param string $honeypotFieldName
+     * 
+     * @return self
+     */
+    public function setHoneypotFieldName(string $honeypotFieldName): self
+    {
+        $this->honeypotFieldName = $honeypotFieldName;
 
         return $this;
     }

--- a/tests/AkismetTest.php
+++ b/tests/AkismetTest.php
@@ -156,6 +156,34 @@ class AkismetTest extends TestCase
         $this->assertSame('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36', $this->akismet->getUserAgent());
     }
 
+    public function test_it_can_set_a_custom_value_for_the_honeypot_field_name()
+    {
+        $this->akismet->setHoneypotFieldName('A honeypot fieldname');
+
+        $this->assertSame($this->akismet->getHoneypotFieldName(), 'A honeypot fieldname');
+    }
+
+    public function test_it_can_set_a_custom_value_for_the_hidden_honeypot_field()
+    {
+        $this->akismet->setHiddenHoneypotField('A hidden honeypot field value');
+
+        $this->assertSame($this->akismet->getHiddenHoneypotField(), 'A hidden honeypot field value');
+    }
+
+    public function test_it_can_set_null_as_honeypot_field_name()
+    {
+        $this->akismet->setHoneypotFieldName(null);
+
+        $this->assertSame($this->akismet->getHoneypotFieldName(), null);
+    }
+
+    public function test_it_can_set_null_as_hidden_honeypot_field()
+    {
+        $this->akismet->setHiddenHoneypotField(null);
+
+        $this->assertSame($this->akismet->getHiddenHoneypotField(), null);
+    }
+
     public function test_it_can_set_multiple_comment_empty_values_at_once()
     {
         $this->akismet->fill(['comment_type' => '', 'comment_author' => '', 'comment_author_email' => '', 'comment_content' => '']);
@@ -174,6 +202,28 @@ class AkismetTest extends TestCase
         $this->assertSame($this->akismet->getCommentAuthor(), null);
         $this->assertSame($this->akismet->getCommentAuthorEmail(), null);
         $this->assertSame($this->akismet->getCommentContent(), null);
+    }
+
+    public function test_it_can_set_multiple_honeypot_empty_values_at_once()
+    {
+        $this->akismet->fill([
+            'honeypot_field_name' => '',
+            'hidden_honeypot_field' => '',
+        ]);
+
+        $this->assertSame($this->akismet->getHoneypotFieldName(), '');
+        $this->assertSame($this->akismet->getHiddenHoneypotField(), '');
+    }
+
+    public function test_it_can_set_multiple_honeypot_nulled_values_at_once()
+    {
+        $this->akismet->fill([
+            'honeypot_field_name' => null,
+            'hidden_honeypot_field' => null,
+        ]);
+
+        $this->assertSame($this->akismet->getHoneypotFieldName(), null);
+        $this->assertSame($this->akismet->getHiddenHoneypotField(), null);
     }
 
     public function test_it_can_work_with_app_instance()


### PR DESCRIPTION
Added honeypot support as described in the Akismet documentation as described here > https://akismet.com/developers/detailed-docs/comment-check/ 

You've added two attributes, why did you do that?
> honeypot_field_name
If you use a [honeypot field](https://en.wikipedia.org/wiki/Honeypot_(computing)) in your implementation, include the name of the field in your request as well as the value of that field. For example, if you have a honeypot field that looks like <input type=”text” name=”hidden_honeypot_field” style=”display: none;” />, then you should include two extra parameters in your request: honeypot_field_name=hidden_honeypot_field and hidden_honeypot_field=[the value of the input].

Closes #48 (There's no extra checks for `setApiBaseUrl()` since I don't have time at this moment, so you might not want to close it, let me know @nickurt)