### PR TITLE
Fix bug when validateKey http post fails

### DIFF
--- a/src/Akismet.php
+++ b/src/Akismet.php
@@ -541,7 +541,7 @@ class Akismet
                 'blog' => $this->getBlogUrl(),
             ]);
         } catch (\Exception $e) {
-            $response = $e->getMessage();
+            return false;
         }
 
         if ($response->header('X-akismet-debug-help')) {


### PR DESCRIPTION
When the http post in ->validateKey() fails it should return boolean.

It was setting a string in the $response var causing the header X-akismet-debug-help check to fail.